### PR TITLE
update memory commitments

### DIFF
--- a/freecinc-com/templates/deployment.yaml
+++ b/freecinc-com/templates/deployment.yaml
@@ -80,8 +80,10 @@ spec:
           resources:
             limits:
               cpu: 100m
+              memory: 400Mi
             requests:
-              cpu: 50m
+              cpu: 10m
+              memory: 100Mi
         - name: freecinc-taskd
           image: "{{ .Values.taskdImage.repository }}:{{ .Values.taskdImage.tag }}"
           imagePullPolicy: {{ .Values.taskdImage.pullPolicy }}
@@ -112,5 +114,7 @@ spec:
           resources:
             limits:
               cpu: 100m
+              memory: 1000Mi
             requests:
               cpu: 50m
+              memory: 100Mi


### PR DESCRIPTION
Taskd leaks, pretty badly.  So 100Mi is generous at startup, helping k8s
to schedule the pod (for some reason, despite the deployment being
Replaced, k8s can't seem to schedule the new pod in the same RAM as the
old pod).