### PR TITLE
increase the liveness probe for taskd

### DIFF
--- a/freecinc-com/templates/deployment.yaml
+++ b/freecinc-com/templates/deployment.yaml
@@ -104,8 +104,8 @@ spec:
           livenessProbe:
             tcpSocket:
               port: taskd
-            initialDelaySeconds: 15
-            periodSeconds: 30
+            initialDelaySeconds: 60
+            periodSeconds: 300
           readinessProbe:
             tcpSocket:
               port: taskd


### PR DESCRIPTION
I suspect that the liveness probe, which makes a TCP connection and
immediately drops it, is causing a memory leak in taskd which is causing
it to be evicted and restarted frequently.  So, let's try polling it
less frequently.